### PR TITLE
feat: add required scope for sending emails and creating events

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -8,8 +8,16 @@ export const authOptions: NextAuthOptions = {
       clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
       authorization: {
         params: {
-          scope:
-            "openid profile email https://www.googleapis.com/auth/contacts.readonly",
+          scope: [
+            "openid",
+            "profile",
+            "email",
+            "https://www.googleapis.com/auth/calendar",
+            "https://www.googleapis.com/auth/contacts.readonly",
+            "https://www.googleapis.com/auth/tasks",
+            "https://www.googleapis.com/auth/gmail.send",
+            "https://mail.google.com/",
+          ].join(" "),
         },
       },
     }),


### PR DESCRIPTION
add required scopes for google access to:
1. gmail
2. calendar
3. task